### PR TITLE
Fix protect member add gui problems? 

### DIFF
--- a/src/main/java/dev/slne/protect/bukkit/KotlinConversationUtils.kt
+++ b/src/main/java/dev/slne/protect/bukkit/KotlinConversationUtils.kt
@@ -1,0 +1,23 @@
+package dev.slne.protect.bukkit
+
+import dev.slne.surf.surfapi.core.api.service.PlayerLookupService
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import java.util.UUID
+import java.util.concurrent.CompletableFuture
+
+object KotlinConversationUtils {
+    fun getUuidAsync(username: String): CompletableFuture<UUID?> {
+        val future = CompletableFuture<UUID?>()
+        CoroutineScope(Dispatchers.IO).launch {
+            try {
+                val result = PlayerLookupService.getUuid(username)
+                future.complete(result)
+            } catch (e: Exception) {
+                future.completeExceptionally(e)
+            }
+        }
+        return future
+    }
+}

--- a/src/main/java/dev/slne/protect/bukkit/gui/anvil/requirement/requirements/player/AnvilOfflinePlayerRequirement.java
+++ b/src/main/java/dev/slne/protect/bukkit/gui/anvil/requirement/requirements/player/AnvilOfflinePlayerRequirement.java
@@ -1,6 +1,6 @@
 package dev.slne.protect.bukkit.gui.anvil.requirement.requirements.player;
 
-import dev.slne.data.api.util.PlayerFinder;
+import dev.slne.protect.bukkit.KotlinConversationUtils;
 import dev.slne.protect.bukkit.gui.anvil.requirement.AnvilRequirement;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -27,7 +27,7 @@ public class AnvilOfflinePlayerRequirement implements AnvilRequirement {
       return CompletableFuture.completedFuture(false);
     }
 
-    return PlayerFinder.getUuidByPlayerName(input).thenApplyAsync(uuid -> {
+    return KotlinConversationUtils.INSTANCE.getUuidAsync(input).thenApplyAsync(uuid -> {
       if (uuid == null) {
         return false;
       }


### PR DESCRIPTION
This pull request introduces a utility class for asynchronous UUID lookup and updates the `AnvilOfflinePlayerRequirement` class to use this new utility. These changes improve code modularity and streamline asynchronous operations.

### New utility for asynchronous UUID lookup:

* [`src/main/java/dev/slne/protect/bukkit/KotlinConversationUtils.kt`](diffhunk://#diff-87c2924462cdce944da8c2c4802f2e388b868020b7da67422777cab63714be02R1-R23): Added the `KotlinConversationUtils` object, which provides the `getUuidAsync` method for asynchronous UUID lookup using `PlayerLookupService`. This method uses coroutines for non-blocking operations and returns a `CompletableFuture`.

### Refactoring to use the new utility:

* [`src/main/java/dev/slne/protect/bukkit/gui/anvil/requirement/requirements/player/AnvilOfflinePlayerRequirement.java`](diffhunk://#diff-5846e275d575c1769a9d096b133e243df57535a37db24b38edbc67110e0eefa3L30-R30): Replaced the usage of `PlayerFinder.getUuidByPlayerName` with `KotlinConversationUtils.INSTANCE.getUuidAsync` for UUID lookup in the `isMet` method. This change simplifies the code and leverages the new utility for better asynchronous handling.
* [`src/main/java/dev/slne/protect/bukkit/gui/anvil/requirement/requirements/player/AnvilOfflinePlayerRequirement.java`](diffhunk://#diff-5846e275d575c1769a9d096b133e243df57535a37db24b38edbc67110e0eefa3L3-R3): Updated imports to replace `PlayerFinder` with `KotlinConversationUtils`.