### PR TITLE
Revert "fix: remove prefix in dialog"

### DIFF
--- a/src/main/kotlin/dev/slne/surf/protect/paper/menu/dialog/ProtectionAddMemberDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/protect/paper/menu/dialog/ProtectionAddMemberDialog.kt
@@ -22,6 +22,7 @@ fun protectionAddMemberDialog(protection: RegionInfo) = searchDialog(
         plainMessage {
             protectColored("Gib den Namen des Spielers ein, den du hinzufügen möchtest.")
             appendNewline()
+            appendWarningPrefix()
             error("Der Spieler muss bereits einmal auf diesem Server gespielt haben, damit er hinzugefügt werden kann.")
         }
     },

--- a/src/main/kotlin/dev/slne/surf/protect/paper/menu/dialog/ProtectionAddMemberDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/protect/paper/menu/dialog/ProtectionAddMemberDialog.kt
@@ -4,6 +4,7 @@ import dev.slne.surf.protect.paper.menu.util.protectColored
 import dev.slne.surf.protect.paper.menu.view.members.ProtectionMemberListView
 import dev.slne.surf.protect.paper.region.info.RegionInfo
 import dev.slne.surf.protect.paper.region.visual.visualizer.ProtectionVisualizerManager
+import dev.slne.surf.protect.paper.util.appendWarnPrefix
 import dev.slne.surf.surfapi.bukkit.api.dialog.search.searchDialog
 import dev.slne.surf.surfapi.bukkit.api.inventory.framework.viewFrame
 import dev.slne.surf.surfapi.core.api.messages.adventure.sendText
@@ -22,7 +23,7 @@ fun protectionAddMemberDialog(protection: RegionInfo) = searchDialog(
         plainMessage {
             protectColored("Gib den Namen des Spielers ein, den du hinzufügen möchtest.")
             appendNewline()
-            appendWarningPrefix()
+            appendWarnPrefix()
             error("Der Spieler muss bereits einmal auf diesem Server gespielt haben, damit er hinzugefügt werden kann.")
         }
     },

--- a/src/main/kotlin/dev/slne/surf/protect/paper/menu/dialog/ProtectionRenameDialog.kt
+++ b/src/main/kotlin/dev/slne/surf/protect/paper/menu/dialog/ProtectionRenameDialog.kt
@@ -8,6 +8,7 @@ import dev.slne.surf.protect.paper.menu.view.ProtectionInfoView
 import dev.slne.surf.protect.paper.plugin
 import dev.slne.surf.protect.paper.region.info.ProtectionFlagInfo
 import dev.slne.surf.protect.paper.region.info.RegionInfo
+import dev.slne.surf.protect.paper.util.appendWarnPrefix
 import dev.slne.surf.protect.paper.util.castCoinFormat
 import dev.slne.surf.surfapi.bukkit.api.dialog.search.searchDialog
 import dev.slne.surf.surfapi.bukkit.api.inventory.framework.viewFrame
@@ -30,11 +31,11 @@ fun protectionRenameDialog(protection: RegionInfo) = searchDialog(
         plainMessage {
             protectColored("Gib den neuen Namen für dein Grundstück ein.")
             appendNewline()
-            appendWarningPrefix()
+            appendWarnPrefix()
             error("Dieser Vorgang kostet dich ${castCoinFormat.format(config.protection.renamePrice)}!")
 
             appendNewline()
-            appendWarningPrefix()
+            appendWarnPrefix()
             error("Der Name darf maximal 22 Zeichen lang sein!")
         }
     },

--- a/src/main/kotlin/dev/slne/surf/protect/paper/util/util.kt
+++ b/src/main/kotlin/dev/slne/surf/protect/paper/util/util.kt
@@ -12,6 +12,7 @@ import com.sk89q.worldguard.protection.managers.RegionManager
 import com.sk89q.worldguard.protection.regions.ProtectedRegion
 import com.sk89q.worldguard.protection.regions.RegionContainer
 import dev.slne.surf.protect.paper.region.flags.ProtectionFlagsRegistry
+import dev.slne.surf.surfapi.core.api.messages.builder.SurfComponentBuilder
 import dev.slne.surf.surfapi.core.api.util.mutableObjectSetOf
 import dev.slne.surf.surfapi.core.api.util.toObjectList
 import io.papermc.paper.math.Position
@@ -265,6 +266,12 @@ fun ChunkSnapshot.getBlockDataAt(
     blockZ: Int
 ): BlockData {
     return getBlockData(blockX and 15, blockY, blockZ and 15)
+}
+
+fun SurfComponentBuilder.appendWarnPrefix() = append {
+    darkSpacer("[")
+    warning("⚠")
+    darkSpacer("] ")
 }
 
 fun WorldEditLocation?.formatString() =


### PR DESCRIPTION
This reverts commit feab8bc6a6a6a540ab4e94bff78d516d548b517e.

The prefix is intended as a Warning Indicator.