### PR TITLE
Add environment-based icons for region protection

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 kotlin.code.style=official
 kotlin.stdlib.default.dependency=false
 org.gradle.parallel=true
-version=3.2.9
+version=3.2.10

--- a/src/main/kotlin/dev/slne/surf/protect/paper/config/ProtectionConfig.kt
+++ b/src/main/kotlin/dev/slne/surf/protect/paper/config/ProtectionConfig.kt
@@ -9,6 +9,7 @@ import org.bukkit.World
 import org.bukkit.block.BlockType
 import org.bukkit.block.data.BlockData
 import org.bukkit.inventory.ItemStack
+import org.bukkit.inventory.ItemType
 import org.spongepowered.configurate.objectmapping.ConfigSerializable
 import pl.allegro.finance.tradukisto.ValueConverters
 import java.io.ByteArrayInputStream
@@ -40,6 +41,12 @@ data class ProtectionConfig(
         val maxNameLength: Int = 22,
         val protectOnlyAboveNetherRoofInNether: Boolean = true,
         val canEnterProtectionModeBelowNetherRoofInNether: Boolean = false,
+
+        val iconByEnvironment: Map<World.Environment, ItemType> = mapOf(
+            World.Environment.NORMAL to ItemType.GRASS_BLOCK,
+            World.Environment.NETHER to ItemType.CRIMSON_NYLIUM,
+            World.Environment.THE_END to ItemType.END_STONE,
+        )
     ) {
         val retailModifier: Double
             get() = retailPercent / 100.0

--- a/src/main/kotlin/dev/slne/surf/protect/paper/menu/util/view-util.kt
+++ b/src/main/kotlin/dev/slne/surf/protect/paper/menu/util/view-util.kt
@@ -7,6 +7,7 @@ import dev.slne.surf.api.paper.builder.LoreBuilder
 import dev.slne.surf.api.paper.builder.buildItem
 import dev.slne.surf.api.paper.builder.buildLore
 import dev.slne.surf.api.paper.builder.displayName
+import dev.slne.surf.protect.paper.config
 import dev.slne.surf.protect.paper.region.info.RegionInfo
 import dev.slne.surf.protect.paper.util.blockFormat
 import dev.slne.surf.protect.paper.util.castCoinFormat
@@ -106,14 +107,19 @@ val closeItem = MenuHeads.CROSS.apply {
 @Suppress("UnstableApiUsage")
 fun createRegionItem(
     protection: RegionInfo,
-    baseItemStack: ItemStack = ItemType.DIRT.createItemStack(),
+    baseItemStack: ItemStack? = null,
     showMoreInfo: Boolean = true
-) = baseItemStack.apply {
-    displayName {
-        variableValue(protection.name)
-    }
+): ItemStack {
+    val item = baseItemStack ?: (protection.world?.environment?.let { config.protection.iconByEnvironment[it] }
+        ?: ItemType.GRASS_BLOCK).createItemStack()
 
-    lore(renderRegionInformation(protection, showMoreInfo))
+    return item.apply {
+        displayName {
+            variableValue(protection.name)
+        }
+
+        lore(renderRegionInformation(protection, showMoreInfo))
+    }
 }
 
 fun renderRegionInformation(

--- a/src/main/kotlin/dev/slne/surf/protect/paper/menu/view/ProtectionMainView.kt
+++ b/src/main/kotlin/dev/slne/surf/protect/paper/menu/view/ProtectionMainView.kt
@@ -126,7 +126,7 @@ val protectionMainView = surfView("Grundstuecke") {
     }
 }
 
-private val protectListItem = buildItem(ItemType.DIRT) {
+private val protectListItem = buildItem(ItemType.GRASS_BLOCK) {
     displayName {
         protectColored("Meine Grundstücke".toSmallCaps(), TextDecoration.BOLD)
     }


### PR DESCRIPTION
This pull request updates the region protection system to allow configurable display icons for protected regions based on the world environment, and makes several related improvements to item selection in the UI. It also includes a minor version bump.

**Configurable region icons:**
- Added a new `iconByEnvironment` property to `ProtectionConfig`, allowing configuration of the display item (`ItemType`) for each `World.Environment` (Overworld, Nether, End). Default values are provided.
- Updated imports to include `ItemType` for use in configuration.

**Menu and UI improvements:**
- Modified `createRegionItem` to select the base item stack according to the region's world environment using the new config, defaulting to grass block if not specified. The function now accepts an optional `baseItemStack` parameter.
- Changed the default item for `protectListItem` in the main protection menu from dirt to grass block for improved visual consistency.
- Added import for `config` to support access to the new configuration in menu utilities.

**Versioning:**
- Bumped the project version from `3.2.9` to `3.2.10`.